### PR TITLE
ローカルスコアが表示されない不具合を修正

### DIFF
--- a/Assets/Prefab/LocalScorePrefab.prefab
+++ b/Assets/Prefab/LocalScorePrefab.prefab
@@ -93,8 +93,8 @@ RectTransform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 160, y: 80}
+  m_SizeDelta: {x: 160, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}

--- a/Assets/Script/LocalScoreController.cs
+++ b/Assets/Script/LocalScoreController.cs
@@ -6,28 +6,32 @@ using UnityEngine.UI;
 //
 // デブリ破壊時にローカルスコアを表示する
 // 破壊された位置からポップしフェードアウトする
+// 本来であれば時間軸に比例するeaseを使うのが妥当。
 //
 public class LocalScoreController : MonoBehaviour {
 
     float elapsedTime;
     Vector3 velocity;
+    float limitTime = 1.0f;
+    float alphaLimit = 0.01f;
 
     // Use this for initialization
     void Start() {
-        velocity = Vector3.up * 10.0f;
+        velocity = Vector3.up * 0.1f;
         elapsedTime = 0;
     }
 
     // Update is called once per frame
     void Update() {
         transform.Translate(velocity);
-        if (velocity.y < 1.0f) {
+        if (velocity.y < alphaLimit) {
+            float alpha = velocity.y / alphaLimit;
             Color c = GetComponent<Text>().color;
-            GetComponent<Text>().color = new Color(c.r, c.g, c.b, velocity.y);
+            GetComponent<Text>().color = new Color(c.r, c.g, c.b, alpha);
         }
         velocity *= 0.9f;
         elapsedTime += Time.deltaTime;
-        if (elapsedTime > 1.0f) {
+        if (elapsedTime > limitTime) {
             Destroy(gameObject);
         }
     }

--- a/Assets/Script/RockController.cs
+++ b/Assets/Script/RockController.cs
@@ -24,7 +24,7 @@ public class RockController : MonoBehaviour {
         int deltaScore = ui.AddScore(scoreSeed);
         Vector2 firstPosition = RectTransformUtility.WorldToScreenPoint(Camera.main, transform.position);
         GameObject localScore = Instantiate(localScorePrefab, firstPosition, Quaternion.identity);
-        localScore.transform.SetParent(canvas.transform);
+        localScore.transform.SetParent(canvas.transform, false);
         localScore.GetComponent<Text>().text = deltaScore.ToString("D");
         // 自身を破壊する
         Destroy(gameObject);


### PR DESCRIPTION
UIとゲームオブジェクト（以下、GO）配置をSceneでプレビューした際に同じ場所に表示されるように、UIゲームオブジェクトで親ゲームオブジェクトのCanvasをスクリーン相対にした。
この影響で、動的に生成していたローカルスコアGOの配置座標系を修正しなければならなかった。